### PR TITLE
genbnecks: run a single MR job

### DIFF
--- a/examples/pydeep/bworker.py
+++ b/examples/pydeep/bworker.py
@@ -1,14 +1,15 @@
 """\
 Calculate bottlenecks for all images in the input stream.
 
-Input key: image label
-Input value: image path
+Input key: image path
+Input value: image content
 """
+from hashlib import md5
 
 import pydoop.mapreduce.api as api
 import pydoop.mapreduce.pipes as pp
 
-from pydeep.ioformats import SamplesReader as Reader
+from pydeep.ioformats import WholeFileReader as Reader
 from pydeep.ioformats import BottleneckProjectionsWriter as Writer
 from pydeep.tflow import BottleneckProjector
 from pydeep.common import GRAPH_ARCH_KEY
@@ -29,7 +30,10 @@ class Mapper(api.Mapper):
     def map(self, context):
         # Here, if needed, we could also generate many derived
         # (distorted) variants of the image
-        context.emit(context.key, self.projector.project(context.value))
+        checksum = md5(context.value).digest()
+        bneck = self.projector.project(context.value)
+        cls = context.key.rsplit("/", 2)[1]
+        context.emit(cls, (checksum, bneck))
 
 
 factory = pp.Factory(mapper_class=Mapper, record_reader_class=Reader,

--- a/examples/pydeep/genbnecks.py
+++ b/examples/pydeep/genbnecks.py
@@ -34,16 +34,12 @@ bottlenecks/
     |-- part-m-00000
     |-- part-m-00001
     `-- _SUCCESS
-
-One separate Hadoop job is submitted for each class.
 """
 
-from copy import deepcopy
-from threading import Thread
-from queue import Queue
 import argparse
 import logging
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -62,7 +58,7 @@ from graph_setup import get_graph
 
 
 LOGGER = logging.getLogger("genbnecks")
-RETVALS = Queue()
+WORKER = "bworker"
 PACKAGE = "pydeep"
 
 DEFAULT_NUM_MAPS = 10
@@ -81,41 +77,14 @@ def make_parser():
     return parser
 
 
-def map_input_files(input_dir):
-    """\
-    Map each class to the list of available files for that class.
-    """
-    img_map = {}
-    ext = frozenset(('jpg', 'jpeg'))
-    with hdfs.hdfs() as fs:
-        for stat in fs.list_directory(input_dir):
-            if stat['kind'] == 'directory':
-                cls = stat['name'].rsplit('/', 1)[-1]
-                img_map[cls] = [
-                    _['name'] for _ in fs.list_directory(stat['name'])
-                    if _['name'].rsplit('.', 1)[-1].lower() in ext
-                ]
-    return img_map
-
-
-def run_map_job(args, unknown_args, images):
-    logger = logging.getLogger(args.job_name)
-    logger.setLevel(args.log_level)
-    splits = common.balanced_split(images, args.num_maps)
-    uri = os.path.join(args.input, '_' + uuid.uuid4().hex)
-    logger.debug("saving input splits to: %s", uri)
-    with hdfs.open(uri, 'wb') as f:
-        write_opaques([OpaqueInputSplit(1, _) for _ in splits], f)
-    submitter = PydoopSubmitter()
-    submitter.set_args(args, [] if unknown_args is None else unknown_args)
-    submitter.properties.update({
-        common.NUM_MAPS_KEY: args.num_maps,
-        common.GRAPH_ARCH_KEY: args.architecture,
-        common.PYDOOP_EXTERNALSPLITS_URI_KEY: uri,
-    })
-    submitter.run()
-    hdfs.rmr(uri)
-    RETVALS.put_nowait(0)
+def list_images(input_dir):
+    ret = []
+    p = re.compile(r".*\.jpe?g$", re.IGNORECASE)
+    ls = [_['name'] for _ in hdfs.lsl(input_dir) if _['kind'] == 'directory']
+    for d in ls:
+        ret.extend([_ for _ in hdfs.ls(d) if p.match(_)])
+    LOGGER.info("%d classes, %d total images", len(ls), len(ret))
+    return ret
 
 
 def main(argv=None):
@@ -127,38 +96,34 @@ def main(argv=None):
 
     parser = make_parser()
     args, unknown_args = parser.parse_known_args(argv)
-    args.job_name = 'genbnecks'
-    args.module = 'bworker'
-    args.upload_file_to_cache = ['bworker.py']
+    args.job_name = WORKER
+    args.module = WORKER
+    args.upload_file_to_cache = ['%s.py' % WORKER]
     args.python_zip = [zip_fn]
     args.do_not_use_java_record_reader = True
     args.do_not_use_java_record_writer = True
+    args.num_reducers = 0
 
     LOGGER.setLevel(args.log_level)
     model = get_model_info(args.architecture)
     get_graph(model, log_level=args.log_level)
 
-    img_map = map_input_files(args.input)
-    LOGGER.info("%d classes, %d total images",
-                len(img_map), sum(map(len, img_map.values())))
-    args.num_reducers = 0
-
-    hdfs.mkdir(args.output)
-    threads = []
-    for cls, img_list in img_map.items():
-        nargs = deepcopy(args)
-        nargs.job_name += '-' + cls
-        nargs.output = os.path.join(nargs.output, cls)
-        t = Thread(target=run_map_job, args=[nargs, unknown_args, img_list])
-        threads.append(t)
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
+    images = list_images(args.input)
+    splits = common.balanced_split(images, args.num_maps)
+    uri = os.path.join(args.input, '_' + uuid.uuid4().hex)
+    LOGGER.debug("saving input splits to: %s", uri)
+    with hdfs.open(uri, 'wb') as f:
+        write_opaques([OpaqueInputSplit(1, _) for _ in splits], f)
+    submitter = PydoopSubmitter()
+    submitter.set_args(args, [] if unknown_args is None else unknown_args)
+    submitter.properties.update({
+        common.NUM_MAPS_KEY: args.num_maps,
+        common.GRAPH_ARCH_KEY: args.architecture,
+        common.PYDOOP_EXTERNALSPLITS_URI_KEY: uri,
+    })
+    submitter.run()
+    hdfs.rmr(uri)
     shutil.rmtree(wd)
-    if RETVALS.qsize() < len(threads):
-        sys.exit("ERROR: one or more workers failed")
 
 
 if __name__ == "__main__":

--- a/examples/pydeep/local_retrain.py
+++ b/examples/pydeep/local_retrain.py
@@ -19,7 +19,7 @@ from pydeep.ioformats import BottleneckStore
 from pydeep.common import LOG_LEVELS
 
 from graph_setup import get_graph
-from genbnecks import map_input_files
+from genbnecks import list_images
 
 logging.basicConfig()
 LOGGER = logging.getLogger("local_retrain")
@@ -55,6 +55,14 @@ def make_parser():
     parser.add_argument("--log-level", metavar="|".join(LOG_LEVELS),
                         choices=LOG_LEVELS, default="INFO")
     return parser
+
+
+def map_input_files(input_dir):
+    ret = {}
+    for path in list_images(input_dir):
+        cls = path.rsplit("/", 2)[1]
+        ret.setdefault(cls, []).append(path)
+    return ret
 
 
 def calc_bottlenecks(model, img_map, out_dir):


### PR DESCRIPTION
Trying to scale to >100 classes led to libhdfs failures. This should be more robust. Also, load balance should be better when different classes have a different number of images.